### PR TITLE
Updated AccessGrant so timeout now matches AuthController's access_tokens

### DIFF
--- a/app/models/access_grant.rb
+++ b/app/models/access_grant.rb
@@ -24,10 +24,8 @@ class AccessGrant < ActiveRecord::Base
     end
   end
 
-  # Note: This is currently hard coded to 2 days, but it could be configurable 
-  # per-user-type or per-application.
-  # No need for this to be constant like this.
+  # Note: This is currently configured through devise, and matches the AuthController access token life 
   def start_expiry_period!
-    self.update_attribute(:access_token_expires_at, 2.days.from_now)
+    self.update_attribute(:access_token_expires_at, Time.now + Devise.timeout_in)
   end
 end


### PR DESCRIPTION
Based on the conversation in issue #7, I have set the AccessGrant to last for Devise.timeout_in (30 minutes by default).
