### PR TITLE
Remove unused before_filter reference

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,6 +1,4 @@
 class RegistrationsController < Devise::RegistrationsController
-  before_filter :save_referrer, :only => :edit
-
   def new
      # Building the resource with information that MAY BE available from omniauth!
      build_resource(:first_name => session[:omniauth] && session[:omniauth]['user_info'] && session[:omniauth]['user_info']['first_name'],


### PR DESCRIPTION
I ran into an undefined method error... According to the authors [comment](http://blog.joshsoftware.com/2010/12/16/multiple-applications-with-devise-omniauth-and-single-sign-on/#comment-1957):

> save_referrer is a stagnant method and we can remove it now

So, this PR just removes the `before_filter` call.
